### PR TITLE
Feature/talk maker polish

### DIFF
--- a/src/features/gallery/tool/talk-maker/components/ImageCropModal.tsx
+++ b/src/features/gallery/tool/talk-maker/components/ImageCropModal.tsx
@@ -106,17 +106,24 @@ export const ImageCropModal: FC<Props> = ({
   const coverScale = naturalSize
     ? Math.max(viewportW / naturalSize.w, viewportH / naturalSize.h)
     : 1;
-  const dispW = naturalSize ? naturalSize.w * coverScale * zoom : viewportW;
-  const dispH = naturalSize ? naturalSize.h * coverScale * zoom : viewportH;
+  // 指定した zoom における表示サイズを都度計算する（zoom変更時に古いサイズで
+  // クランプしてしまうと、縮小時に枠内へ空白が出てしまうため）
+  const getDispSize = (z: number) => ({
+    w: naturalSize ? naturalSize.w * coverScale * z : viewportW,
+    h: naturalSize ? naturalSize.h * coverScale * z : viewportH,
+  });
+  const { w: dispW, h: dispH } = getDispSize(zoom);
 
-  const clampOffset = (x: number, y: number) => {
-    const maxX = Math.max(0, (dispW - viewportW) / 2);
-    const maxY = Math.max(0, (dispH - viewportH) / 2);
+  const clampOffsetForSize = (x: number, y: number, w: number, h: number) => {
+    const maxX = Math.max(0, (w - viewportW) / 2);
+    const maxY = Math.max(0, (h - viewportH) / 2);
     return {
       x: Math.min(maxX, Math.max(-maxX, x)),
       y: Math.min(maxY, Math.max(-maxY, y)),
     };
   };
+  const clampOffset = (x: number, y: number) =>
+    clampOffsetForSize(x, y, dispW, dispH);
 
   const handlePointerDown = (e: PointerEvent<HTMLDivElement>) => {
     e.currentTarget.setPointerCapture(e.pointerId);
@@ -226,7 +233,12 @@ export const ImageCropModal: FC<Props> = ({
               value={zoom}
               onChange={(v) => {
                 setZoom(v);
-                setOffset((prev) => clampOffset(prev.x, prev.y));
+                // 新しい zoom の表示サイズでクランプする（古いサイズのままだと
+                // 縮小時に枠内へ空白が出てしまう）
+                const next = getDispSize(v);
+                setOffset((prev) =>
+                  clampOffsetForSize(prev.x, prev.y, next.w, next.h)
+                );
               }}
               colorScheme="teal"
             >

--- a/src/features/gallery/tool/talk-maker/components/MessageBubble.tsx
+++ b/src/features/gallery/tool/talk-maker/components/MessageBubble.tsx
@@ -33,6 +33,7 @@ import {
 import {
   CALL_STATUS_LABELS,
   DEFAULT_CALL_COMPLETED_TEXT,
+  getIconFontSize,
 } from '../utils/presets';
 import { normalizeTime } from '../utils/time';
 
@@ -40,7 +41,7 @@ type Props = {
   message: TalkMessage;
   theme: BackgroundTheme;
   settings: TalkSettings;
-  /** 送信メンバー（sender==='other' のとき）。未指定時は settings.partnerIcon を使う */
+  /** 送信メンバー（sender==='other' のとき。呼び出し側で必ず解決して渡すこと） */
   member?: TalkMember;
   /** 同一送信者の連投時は false にしてアイコンを省略する */
   showIcon: boolean;
@@ -108,7 +109,7 @@ const MessageBubbleBase: FC<Props> = ({
     </VStack>
   );
 
-  const avatarIcon = member?.icon ?? settings.partnerIcon;
+  const avatarIcon = member?.icon ?? '';
   const avatarImage = member?.iconImage;
 
   const bubbleBody: ReactNode = isImage ? (
@@ -224,7 +225,9 @@ const MessageBubbleBase: FC<Props> = ({
     <Flex
       justify={isMe ? 'flex-end' : 'flex-start'}
       align="flex-end"
-      gap="4px"
+      // 吹き出しの尻尾（下記_beforeで6px突き出す）がアバターの円に重なって
+      // 視覚的に欠けて見えないよう、余白を尻尾の突き出し幅以上に確保する
+      gap="8px"
       px={3}
       data-testid="message-bubble"
     >
@@ -238,7 +241,7 @@ const MessageBubbleBase: FC<Props> = ({
               bg="whiteAlpha.900"
               align="center"
               justify="center"
-              fontSize="20px"
+              fontSize={getIconFontSize(avatarIcon, 20)}
               boxShadow="sm"
               overflow="hidden"
             >
@@ -266,6 +269,11 @@ const MessageBubbleBase: FC<Props> = ({
         direction="column"
         align={isMe ? 'flex-end' : 'flex-start'}
         maxW="70%"
+        // 親(横並びFlex)の flex item として、デフォルトの min-width:auto の
+        // ままだと長い区切りのないテキスト（スペースなしの日本語連文等）で
+        // maxW が無視されて吹き出しが伸び、時刻が右に押し出されて改行される。
+        // minW={0} で明示的に縮小を許可し、wordBreak による折り返しを効かせる。
+        minW={0}
       >
         {showName && !isMe && member && (
           <Text
@@ -273,175 +281,200 @@ const MessageBubbleBase: FC<Props> = ({
             color={theme.metaColor}
             mb="2px"
             lineHeight="1.2"
+            // 列（Flex direction="column"）は align が flex-start/flex-end のため
+            // 子要素は横方向にstretchされず、幅を明示しないと内容に合わせて
+            // 際限なく伸びてしまう。maxW="100%" で列の幅を継承させたうえで
+            // 折り返す（吹き出し本文の maxW="100%" と同じ対応）
+            maxW="100%"
+            whiteSpace="pre-wrap"
+            wordBreak="break-word"
           >
             {member.name}
           </Text>
         )}
-        {selectionMode ? (
-          bubbleBox
-        ) : (
-          <Popover isLazy placement={isMe ? 'left' : 'right'}>
-            <PopoverTrigger>{bubbleBox}</PopoverTrigger>
-            <PopoverContent w="240px">
-              <PopoverArrow />
-              <PopoverBody>
-                <VStack spacing={3} align="stretch">
-                  {!isImage && !isCall && (
-                    <FormControl>
-                      <FormLabel fontSize="xs" mb={1}>
-                        メッセージ
-                      </FormLabel>
-                      <Textarea
-                        size="sm"
-                        rows={2}
-                        value={message.text}
-                        onChange={(e) => onUpdate({ text: e.target.value })}
-                      />
-                    </FormControl>
-                  )}
+        {/*
+          時刻(meta)は列全体ではなく、この行の中で吹き出し自身と並べて配置する。
+          列は名前ラベルの幅にも合わせて伸びるため、列の外に時刻を置くと
+          （名前ラベルが長い時に）吹き出しではなく列の右端に時刻が寄ってしまう。
+          alignSelf="stretch" + minW={0} で列の幅いっぱいまで使えるようにしつつ、
+          中身は吹き出しの実際の幅に合わせて詰める。
+        */}
+        <Flex
+          align="flex-end"
+          gap="4px"
+          alignSelf="stretch"
+          minW={0}
+          justify={isMe ? 'flex-end' : 'flex-start'}
+        >
+          {selectionMode ? (
+            bubbleBox
+          ) : (
+            <Popover isLazy placement={isMe ? 'left' : 'right'}>
+              <PopoverTrigger>{bubbleBox}</PopoverTrigger>
+              <PopoverContent w="240px">
+                <PopoverArrow />
+                <PopoverBody>
+                  <VStack spacing={3} align="stretch">
+                    {!isImage && !isCall && (
+                      <FormControl>
+                        <FormLabel fontSize="xs" mb={1}>
+                          メッセージ
+                        </FormLabel>
+                        <Textarea
+                          size="sm"
+                          rows={2}
+                          value={message.text}
+                          onChange={(e) => onUpdate({ text: e.target.value })}
+                        />
+                      </FormControl>
+                    )}
 
-                  {isCall && callStatus === 'completed' && (
-                    <FormControl>
-                      <FormLabel fontSize="xs" mb={1}>
-                        通話メッセージ
-                      </FormLabel>
-                      <Textarea
-                        size="sm"
-                        rows={2}
-                        value={message.text}
-                        onChange={(e) => onUpdate({ text: e.target.value })}
-                      />
-                    </FormControl>
-                  )}
+                    {isCall && callStatus === 'completed' && (
+                      <FormControl>
+                        <FormLabel fontSize="xs" mb={1}>
+                          通話メッセージ
+                        </FormLabel>
+                        <Textarea
+                          size="sm"
+                          rows={2}
+                          value={message.text}
+                          onChange={(e) => onUpdate({ text: e.target.value })}
+                        />
+                      </FormControl>
+                    )}
 
-                  {isCall && (
+                    {isCall && (
+                      <Flex gap={2}>
+                        <FormControl>
+                          <FormLabel fontSize="xs" mb={1}>
+                            通話の結果
+                          </FormLabel>
+                          <Select
+                            size="sm"
+                            value={callStatus}
+                            onChange={(e) => {
+                              const next = e.target.value as CallStatus;
+                              onUpdate({
+                                callStatus: next,
+                                // completedへ切り替えた際、文言が空だとバブルが寂しいのでデフォルト文を補う
+                                ...(next === 'completed' && !message.text
+                                  ? { text: DEFAULT_CALL_COMPLETED_TEXT }
+                                  : {}),
+                              });
+                            }}
+                          >
+                            <option value="completed">通話時間</option>
+                            <option value="missed">不在着信</option>
+                            <option value="canceled">キャンセル</option>
+                            <option value="noAnswer">応答なし</option>
+                          </Select>
+                        </FormControl>
+                        {callStatus === 'completed' && (
+                          <FormControl>
+                            <FormLabel fontSize="xs" mb={1}>
+                              通話時間
+                            </FormLabel>
+                            <Input
+                              size="sm"
+                              value={message.callDuration ?? ''}
+                              placeholder="0:22"
+                              onChange={(e) =>
+                                onUpdate({ callDuration: e.target.value })
+                              }
+                            />
+                          </FormControl>
+                        )}
+                      </Flex>
+                    )}
+
                     <Flex gap={2}>
                       <FormControl>
                         <FormLabel fontSize="xs" mb={1}>
-                          通話の結果
+                          時刻
                         </FormLabel>
-                        <Select
+                        <Input
                           size="sm"
-                          value={callStatus}
-                          onChange={(e) => {
-                            const next = e.target.value as CallStatus;
-                            onUpdate({
-                              callStatus: next,
-                              // completedへ切り替えた際、文言が空だとバブルが寂しいのでデフォルト文を補う
-                              ...(next === 'completed' && !message.text
-                                ? { text: DEFAULT_CALL_COMPLETED_TEXT }
-                                : {}),
-                            });
-                          }}
-                        >
-                          <option value="completed">通話時間</option>
-                          <option value="missed">不在着信</option>
-                          <option value="canceled">キャンセル</option>
-                          <option value="noAnswer">応答なし</option>
-                        </Select>
+                          value={timeDraft}
+                          onChange={(e) => setTimeDraft(e.target.value)}
+                          onBlur={commitTime}
+                          placeholder="12:34"
+                        />
                       </FormControl>
-                      {callStatus === 'completed' && (
+                      {/* 既読は自分のメッセージにしか表示されないため、トグルも自分のときのみ出す */}
+                      {isMe && (
                         <FormControl>
                           <FormLabel fontSize="xs" mb={1}>
-                            通話時間
+                            既読
                           </FormLabel>
-                          <Input
-                            size="sm"
-                            value={message.callDuration ?? ''}
-                            placeholder="0:22"
+                          <Switch
+                            isChecked={message.read}
                             onChange={(e) =>
-                              onUpdate({ callDuration: e.target.value })
+                              onUpdate({ read: e.target.checked })
                             }
+                            colorScheme="teal"
                           />
                         </FormControl>
                       )}
                     </Flex>
-                  )}
 
-                  <Flex gap={2}>
-                    <FormControl>
-                      <FormLabel fontSize="xs" mb={1}>
-                        時刻
-                      </FormLabel>
-                      <Input
-                        size="sm"
-                        value={timeDraft}
-                        onChange={(e) => setTimeDraft(e.target.value)}
-                        onBlur={commitTime}
-                        placeholder="12:34"
-                      />
-                    </FormControl>
-                    {/* 既読は自分のメッセージにしか表示されないため、トグルも自分のときのみ出す */}
-                    {isMe && (
+                    {/* グループ時は送信メンバーを変更できる */}
+                    {!isMe && settings.members.length >= 2 && (
                       <FormControl>
                         <FormLabel fontSize="xs" mb={1}>
-                          既読
+                          送信メンバー
                         </FormLabel>
-                        <Switch
-                          isChecked={message.read}
-                          onChange={(e) => onUpdate({ read: e.target.checked })}
-                          colorScheme="teal"
-                        />
+                        <Select
+                          size="sm"
+                          value={member?.id ?? settings.members[0].id}
+                          onChange={(e) =>
+                            onUpdate({ memberId: e.target.value })
+                          }
+                        >
+                          {settings.members.map((m) => (
+                            <option key={m.id} value={m.id}>
+                              {m.name}
+                            </option>
+                          ))}
+                        </Select>
                       </FormControl>
                     )}
-                  </Flex>
 
-                  {/* グループ時は送信メンバーを変更できる */}
-                  {!isMe && settings.members.length >= 2 && (
-                    <FormControl>
-                      <FormLabel fontSize="xs" mb={1}>
-                        送信メンバー
-                      </FormLabel>
-                      <Select
-                        size="sm"
-                        value={member?.id ?? settings.members[0].id}
-                        onChange={(e) => onUpdate({ memberId: e.target.value })}
+                    <ButtonGroup size="xs" isAttached w="100%">
+                      <Button
+                        flex={1}
+                        colorScheme="teal"
+                        variant={isMe ? 'outline' : 'solid'}
+                        onClick={() => onUpdate({ sender: 'other' })}
                       >
-                        {settings.members.map((m) => (
-                          <option key={m.id} value={m.id}>
-                            {m.name}
-                          </option>
-                        ))}
-                      </Select>
-                    </FormControl>
-                  )}
+                        相手
+                      </Button>
+                      <Button
+                        flex={1}
+                        colorScheme="teal"
+                        variant={isMe ? 'solid' : 'outline'}
+                        onClick={() => onUpdate({ sender: 'me' })}
+                      >
+                        自分
+                      </Button>
+                    </ButtonGroup>
 
-                  <ButtonGroup size="xs" isAttached w="100%">
                     <Button
-                      flex={1}
-                      colorScheme="teal"
-                      variant={isMe ? 'outline' : 'solid'}
-                      onClick={() => onUpdate({ sender: 'other' })}
+                      size="xs"
+                      colorScheme="red"
+                      variant="ghost"
+                      leftIcon={<RiDeleteBin6Line />}
+                      onClick={onDelete}
                     >
-                      相手
+                      このメッセージを削除
                     </Button>
-                    <Button
-                      flex={1}
-                      colorScheme="teal"
-                      variant={isMe ? 'solid' : 'outline'}
-                      onClick={() => onUpdate({ sender: 'me' })}
-                    >
-                      自分
-                    </Button>
-                  </ButtonGroup>
-
-                  <Button
-                    size="xs"
-                    colorScheme="red"
-                    variant="ghost"
-                    leftIcon={<RiDeleteBin6Line />}
-                    onClick={onDelete}
-                  >
-                    このメッセージを削除
-                  </Button>
-                </VStack>
-              </PopoverBody>
-            </PopoverContent>
-          </Popover>
-        )}
+                  </VStack>
+                </PopoverBody>
+              </PopoverContent>
+            </Popover>
+          )}
+          {!isMe && meta}
+        </Flex>
       </Flex>
-
-      {!isMe && meta}
     </Flex>
   );
 };

--- a/src/features/gallery/tool/talk-maker/components/TalkPreview.tsx
+++ b/src/features/gallery/tool/talk-maker/components/TalkPreview.tsx
@@ -1,5 +1,5 @@
 // src/features/gallery/tool/talk-maker/components/TalkPreview.tsx
-import { Box, Flex, Image, Text, VStack } from '@chakra-ui/react';
+import { Box, Flex, Text, VStack } from '@chakra-ui/react';
 import { forwardRef } from 'react';
 import {
   IoCallOutline,
@@ -77,29 +77,6 @@ export const TalkPreview = forwardRef<HTMLDivElement, Props>(
           gap={2}
         >
           <IoChevronBack size={20} />
-          <Flex
-            w="30px"
-            h="30px"
-            borderRadius="full"
-            bg="whiteAlpha.300"
-            align="center"
-            justify="center"
-            fontSize="18px"
-            flexShrink={0}
-            overflow="hidden"
-          >
-            {settings.partnerIconImage ? (
-              <Image
-                src={settings.partnerIconImage}
-                alt="トークアイコン"
-                w="100%"
-                h="100%"
-                objectFit="cover"
-              />
-            ) : (
-              settings.partnerIcon
-            )}
-          </Flex>
           <Text
             fontSize="sm"
             fontWeight="bold"

--- a/src/features/gallery/tool/talk-maker/components/TalkSettingsForm.tsx
+++ b/src/features/gallery/tool/talk-maker/components/TalkSettingsForm.tsx
@@ -13,6 +13,11 @@ import {
   IconButton,
   Image,
   Input,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SimpleGrid,
   Switch,
@@ -26,7 +31,12 @@ import { RiDeleteBin6Line } from 'react-icons/ri';
 import { FontId, TalkMember, TalkSettings } from '../types';
 import { CropShape, ImageCropModal } from './ImageCropModal';
 import { readFileAsDataUrl } from '../utils/image';
-import { FONTS, PARTNER_ICON_OPTIONS, THEMES } from '../utils/presets';
+import {
+  FONTS,
+  PARTNER_ICON_OPTIONS,
+  THEMES,
+  getIconFontSize,
+} from '../utils/presets';
 
 type Props = {
   settings: TalkSettings;
@@ -126,86 +136,6 @@ export const TalkSettingsForm: FC<Props> = ({
                 onChange={(e) => onChange({ partnerName: e.target.value })}
                 maxLength={20}
               />
-            </FormControl>
-
-            <FormControl mb={3}>
-              <FormLabel fontSize="xs" mb={1}>
-                トークアイコン
-              </FormLabel>
-              {settings.partnerIconImage ? (
-                <Flex align="center" gap={2}>
-                  <Image
-                    src={settings.partnerIconImage}
-                    alt="トークアイコン"
-                    w="36px"
-                    h="36px"
-                    borderRadius="full"
-                    objectFit="cover"
-                  />
-                  <Button
-                    size="xs"
-                    variant="ghost"
-                    colorScheme="red"
-                    onClick={() => onChange({ partnerIconImage: undefined })}
-                  >
-                    画像を解除
-                  </Button>
-                </Flex>
-              ) : (
-                <>
-                  <SimpleGrid columns={6} spacing={1} mb={2}>
-                    {PARTNER_ICON_OPTIONS.map((icon) => (
-                      <Flex
-                        key={icon}
-                        as="button"
-                        type="button"
-                        aria-label={`アイコン ${icon}`}
-                        align="center"
-                        justify="center"
-                        h="32px"
-                        fontSize="20px"
-                        borderRadius="md"
-                        border="2px solid"
-                        borderColor={
-                          settings.partnerIcon === icon
-                            ? 'teal.400'
-                            : 'transparent'
-                        }
-                        bg="gray.50"
-                        _hover={{ bg: 'gray.100' }}
-                        onClick={() => onChange({ partnerIcon: icon })}
-                      >
-                        {icon}
-                      </Flex>
-                    ))}
-                  </SimpleGrid>
-                  <Flex gap={2} align="center">
-                    <Input
-                      size="sm"
-                      value={settings.partnerIcon}
-                      onChange={(e) =>
-                        onChange({ partnerIcon: e.target.value })
-                      }
-                      maxLength={2}
-                      w="80px"
-                      textAlign="center"
-                    />
-                    <ImagePickButton
-                      size="sm"
-                      onPick={(src) =>
-                        setCropState({
-                          src,
-                          shape: 'circle',
-                          apply: (cropped) =>
-                            onChange({ partnerIconImage: cropped }),
-                        })
-                      }
-                    >
-                      画像を使う
-                    </ImagePickButton>
-                  </Flex>
-                </>
-              )}
             </FormControl>
 
             <FormControl mb={3}>
@@ -351,29 +281,119 @@ export const TalkSettingsForm: FC<Props> = ({
             <Flex direction="column" gap={2}>
               {settings.members.map((member) => (
                 <Flex key={member.id} align="center" gap={2}>
-                  <Flex
-                    w="30px"
-                    h="30px"
-                    borderRadius="full"
-                    bg="gray.100"
-                    align="center"
-                    justify="center"
-                    fontSize="18px"
-                    flexShrink={0}
-                    overflow="hidden"
-                  >
-                    {member.iconImage ? (
-                      <Image
-                        src={member.iconImage}
-                        alt={member.name}
-                        w="100%"
-                        h="100%"
-                        objectFit="cover"
-                      />
-                    ) : (
-                      member.icon
-                    )}
-                  </Flex>
+                  <Popover placement="bottom-start" isLazy>
+                    <PopoverTrigger>
+                      <Flex
+                        as="button"
+                        type="button"
+                        aria-label={`${member.name} のアイコンを変更`}
+                        w="30px"
+                        h="30px"
+                        borderRadius="full"
+                        bg="gray.100"
+                        align="center"
+                        justify="center"
+                        fontSize={getIconFontSize(member.icon, 18)}
+                        flexShrink={0}
+                        overflow="hidden"
+                        border="2px solid transparent"
+                        _hover={{ borderColor: 'teal.400' }}
+                      >
+                        {member.iconImage ? (
+                          <Image
+                            src={member.iconImage}
+                            alt={member.name}
+                            w="100%"
+                            h="100%"
+                            objectFit="cover"
+                          />
+                        ) : (
+                          member.icon
+                        )}
+                      </Flex>
+                    </PopoverTrigger>
+                    <PopoverContent w="220px">
+                      <PopoverArrow />
+                      <PopoverBody>
+                        <SimpleGrid columns={6} spacing={1} mb={2}>
+                          {PARTNER_ICON_OPTIONS.map((icon) => (
+                            <Flex
+                              key={icon}
+                              as="button"
+                              type="button"
+                              aria-label={`アイコン ${icon}`}
+                              align="center"
+                              justify="center"
+                              h="28px"
+                              fontSize="18px"
+                              borderRadius="md"
+                              border="2px solid"
+                              borderColor={
+                                !member.iconImage && member.icon === icon
+                                  ? 'teal.400'
+                                  : 'transparent'
+                              }
+                              bg="gray.50"
+                              _hover={{ bg: 'gray.100' }}
+                              onClick={() =>
+                                onUpdateMember(member.id, {
+                                  icon,
+                                  iconImage: undefined,
+                                })
+                              }
+                            >
+                              {icon}
+                            </Flex>
+                          ))}
+                        </SimpleGrid>
+                        <Flex gap={2} align="center">
+                          <Input
+                            size="sm"
+                            value={member.icon}
+                            onChange={(e) =>
+                              onUpdateMember(member.id, {
+                                icon: e.target.value,
+                              })
+                            }
+                            maxLength={2}
+                            w="52px"
+                            textAlign="center"
+                            aria-label={`${member.name} の絵文字アイコン`}
+                          />
+                          {member.iconImage ? (
+                            <Button
+                              size="xs"
+                              variant="ghost"
+                              colorScheme="red"
+                              onClick={() =>
+                                onUpdateMember(member.id, {
+                                  iconImage: undefined,
+                                })
+                              }
+                            >
+                              画像解除
+                            </Button>
+                          ) : (
+                            <ImagePickButton
+                              size="xs"
+                              onPick={(src) =>
+                                setCropState({
+                                  src,
+                                  shape: 'circle',
+                                  apply: (cropped) =>
+                                    onUpdateMember(member.id, {
+                                      iconImage: cropped,
+                                    }),
+                                })
+                              }
+                            >
+                              画像を使う
+                            </ImagePickButton>
+                          )}
+                        </Flex>
+                      </PopoverBody>
+                    </PopoverContent>
+                  </Popover>
                   <Input
                     size="sm"
                     value={member.name}
@@ -383,43 +403,6 @@ export const TalkSettingsForm: FC<Props> = ({
                     maxLength={20}
                     flex={1}
                   />
-                  <Input
-                    size="sm"
-                    value={member.icon}
-                    onChange={(e) =>
-                      onUpdateMember(member.id, { icon: e.target.value })
-                    }
-                    maxLength={2}
-                    w="52px"
-                    textAlign="center"
-                    aria-label={`${member.name} の絵文字アイコン`}
-                  />
-                  {member.iconImage ? (
-                    <Button
-                      size="xs"
-                      variant="ghost"
-                      colorScheme="red"
-                      flexShrink={0}
-                      onClick={() =>
-                        onUpdateMember(member.id, { iconImage: undefined })
-                      }
-                    >
-                      画像解除
-                    </Button>
-                  ) : (
-                    <ImagePickButton
-                      onPick={(src) =>
-                        setCropState({
-                          src,
-                          shape: 'circle',
-                          apply: (cropped) =>
-                            onUpdateMember(member.id, { iconImage: cropped }),
-                        })
-                      }
-                    >
-                      画像
-                    </ImagePickButton>
-                  )}
                   <IconButton
                     aria-label={`${member.name} を削除`}
                     icon={<RiDeleteBin6Line />}

--- a/src/features/gallery/tool/talk-maker/components/__tests__/MessageBubble.test.tsx
+++ b/src/features/gallery/tool/talk-maker/components/__tests__/MessageBubble.test.tsx
@@ -69,28 +69,28 @@ describe('MessageBubble', () => {
   });
 
   it('相手のメッセージにはアイコンが表示される', () => {
+    const member = DEFAULT_SETTINGS.members[0];
     render(
       <MessageBubble
         {...defaultProps}
         message={{ ...baseMessage, sender: 'other' }}
+        member={member}
       />
     );
-    expect(
-      screen.getByText(DEFAULT_SETTINGS.partnerIcon)
-    ).toBeInTheDocument();
+    expect(screen.getByText(member.icon)).toBeInTheDocument();
   });
 
   it('showIcon が false のときアイコンを省略する', () => {
+    const member = DEFAULT_SETTINGS.members[0];
     render(
       <MessageBubble
         {...defaultProps}
         message={{ ...baseMessage, sender: 'other' }}
+        member={member}
         showIcon={false}
       />
     );
-    expect(
-      screen.queryByText(DEFAULT_SETTINGS.partnerIcon)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(member.icon)).not.toBeInTheDocument();
   });
 
   it('吹き出しをクリックすると編集ポップオーバーが開き、削除できる', async () => {

--- a/src/features/gallery/tool/talk-maker/hooks/__tests__/useTalkMakerStore.test.ts
+++ b/src/features/gallery/tool/talk-maker/hooks/__tests__/useTalkMakerStore.test.ts
@@ -141,7 +141,6 @@ describe('useTalkMakerStore', () => {
         messages: [],
         settings: {
           partnerName: '太郎',
-          partnerIcon: '🐶',
           themeId: 'dark',
           showTime: true,
           showRead: true,
@@ -153,10 +152,7 @@ describe('useTalkMakerStore', () => {
     await waitFor(() => expect(result.current.initialized).toBe(true));
 
     expect(result.current.settings.members).toHaveLength(1);
-    expect(result.current.settings.members[0]).toMatchObject({
-      name: '太郎',
-      icon: '🐶',
-    });
+    expect(result.current.settings.members[0].name).toBe('太郎');
     expect(result.current.settings.fontId).toBe('gothic');
   });
 

--- a/src/features/gallery/tool/talk-maker/hooks/useTalkMakerStore.ts
+++ b/src/features/gallery/tool/talk-maker/hooks/useTalkMakerStore.ts
@@ -42,12 +42,7 @@ function loadFromStorage(): StoredState {
     // DEFAULT_SETTINGS のスプレッドで members が埋まるため、保存データ側を直接確認する
     const storedMembers = parsed.settings?.members;
     if (!Array.isArray(storedMembers) || storedMembers.length === 0) {
-      settings.members = [
-        createMember({
-          name: settings.partnerName,
-          icon: settings.partnerIcon,
-        }),
-      ];
+      settings.members = [createMember({ name: settings.partnerName })];
     }
     return {
       messages: Array.isArray(parsed.messages) ? parsed.messages : [],

--- a/src/features/gallery/tool/talk-maker/types/index.ts
+++ b/src/features/gallery/tool/talk-maker/types/index.ts
@@ -66,10 +66,6 @@ export interface BackgroundTheme {
 export interface TalkSettings {
   /** ヘッダーに表示するトーク名（1対1なら相手の名前） */
   partnerName: string;
-  /** トークアイコンの絵文字 */
-  partnerIcon: string;
-  /** トークアイコンの画像（dataURL）。設定時は絵文字より優先 */
-  partnerIconImage?: string;
   themeId: ThemeId;
   /** 背景画像（dataURL）。設定時はテーマ背景色の上に cover 表示 */
   backgroundImage?: string;

--- a/src/features/gallery/tool/talk-maker/utils/__tests__/presets.test.ts
+++ b/src/features/gallery/tool/talk-maker/utils/__tests__/presets.test.ts
@@ -2,7 +2,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { CallStatus } from '../../types';
-import { CALL_STATUS_LABELS, getFont, getTheme } from '../presets';
+import {
+  CALL_STATUS_LABELS,
+  getFont,
+  getIconFontSize,
+  getTheme,
+} from '../presets';
 
 describe('CALL_STATUS_LABELS', () => {
   it('completed 以外の全ステータスにラベルを持つ', () => {
@@ -42,5 +47,19 @@ describe('getFont', () => {
   it('不正なIDは先頭フォントにフォールバックする', () => {
     // @ts-expect-error 不正な値を渡すケースを検証する
     expect(getFont('unknown').id).toBe('gothic');
+  });
+});
+
+describe('getIconFontSize', () => {
+  it('絵文字1個（サロゲートペア含む）は基準サイズのまま', () => {
+    expect(getIconFontSize('🐱', 20)).toBe('20px');
+    expect(getIconFontSize('あ', 20)).toBe('20px');
+    expect(getIconFontSize('', 20)).toBe('20px');
+  });
+
+  it('2文字以上は丸窓に収まるよう縮小する', () => {
+    expect(getIconFontSize('ファ', 20)).toBe('12px');
+    expect(getIconFontSize('ああ', 20)).toBe('12px');
+    expect(getIconFontSize('🐱🐶', 18)).toBe('11px');
   });
 });

--- a/src/features/gallery/tool/talk-maker/utils/__tests__/talkJson.test.ts
+++ b/src/features/gallery/tool/talk-maker/utils/__tests__/talkJson.test.ts
@@ -126,9 +126,11 @@ describe('serializeTalk', () => {
       time: '12:38',
       read: true,
     },
+    { id: '6', sender: 'me', text: '', time: '12:39', read: true },
+    { id: '7', sender: 'me', text: '   ', time: '12:40', read: true },
   ];
 
-  it('メンバー名で書き出し、画像・特殊メッセージはスキップする', () => {
+  it('メンバー名で書き出し、画像・特殊メッセージ・空文字はスキップする', () => {
     const json = serializeTalk(messages, existingMembers);
     const parsed = JSON.parse(json) as Array<{ sender: string; text: string }>;
 

--- a/src/features/gallery/tool/talk-maker/utils/exportImage.ts
+++ b/src/features/gallery/tool/talk-maker/utils/exportImage.ts
@@ -1,6 +1,14 @@
 // src/features/gallery/tool/talk-maker/utils/exportImage.ts
 
 /**
+ * pixelRatio=1 で絵文字のズレが軽減されるか実験したが、保存画像の解像度が
+ * 大きく下がり画質が悪化する方が問題だったため 2 に戻した。
+ * アイコンのズレはアバター周りの構造修正（余白調整・中央揃え等）で
+ * 解消した可能性が高く、pixelRatio 自体が原因ではなかったとみられる。
+ */
+const EXPORT_PIXEL_RATIO = 2;
+
+/**
  * プレビューのDOMをPNG画像としてダウンロードする。
  * html-to-image は初期バンドルを軽く保つためエクスポート時に dynamic import する。
  * 失敗時は例外を投げるので、呼び出し側でトースト表示すること。
@@ -9,7 +17,7 @@ export async function exportTalkImage(node: HTMLElement): Promise<void> {
   const { toPng } = await import('html-to-image');
 
   const dataUrl = await toPng(node, {
-    pixelRatio: 2,
+    pixelRatio: EXPORT_PIXEL_RATIO,
     cacheBust: true,
     width: node.offsetWidth,
     height: node.offsetHeight,

--- a/src/features/gallery/tool/talk-maker/utils/presets.ts
+++ b/src/features/gallery/tool/talk-maker/utils/presets.ts
@@ -67,6 +67,18 @@ export function getTheme(id: ThemeId): BackgroundTheme {
   return THEMES.find((t) => t.id === id) ?? THEMES[0];
 }
 
+/**
+ * アイコン欄は入力文字数を厳密に1文字へ制限せず（IME確定タイミングに
+ * 依存し不安定なため）、ネイティブの maxLength={2} で大まかに絞るだけに留める。
+ * その代わり、絵文字1個を超える文字（「ファ」「ああ」等の2文字）が入っていても
+ * 丸いアイコン枠からはみ出さないよう、表示側でフォントサイズを縮小する。
+ */
+export function getIconFontSize(icon: string, baseSizePx: number): string {
+  const glyphCount = Array.from(icon).length;
+  if (glyphCount <= 1) return `${baseSizePx}px`;
+  return `${Math.round(baseSizePx * 0.6)}px`;
+}
+
 /** 相手アイコンの絵文字候補（自由入力も可能） */
 export const PARTNER_ICON_OPTIONS = [
   '🐱',
@@ -143,7 +155,6 @@ export const CALL_STATUS_LABELS: Record<Exclude<CallStatus, 'completed'>, string
 
 export const DEFAULT_SETTINGS: TalkSettings = {
   partnerName: '相手の名前',
-  partnerIcon: '🐱',
   themeId: 'blue',
   fontId: 'gothic',
   showTime: true,

--- a/src/features/gallery/tool/talk-maker/utils/talkJson.ts
+++ b/src/features/gallery/tool/talk-maker/utils/talkJson.ts
@@ -114,13 +114,20 @@ export function parseTalkJson(
  * トークをJSON文字列に変換する。
  * 画像（dataURLが巨大）と特殊メッセージ（通話・日付・システム）は
  * インポート形式で表現できないため対象外（スキップ）とする。
+ * 空文字（吹き出し編集で本文を消した場合）も、text: z.string().min(1) の
+ * インポート検証に弾かれ再インポートできなくなるためスキップする。
  */
 export function serializeTalk(
   messages: TalkMessage[],
   members: TalkMember[]
 ): string {
   const items = messages
-    .filter((m) => !m.imageUrl && (!m.kind || m.kind === 'text'))
+    .filter(
+      (m) =>
+        !m.imageUrl &&
+        (!m.kind || m.kind === 'text') &&
+        m.text.trim().length > 0
+    )
     .map((m) => {
       const member = members.find((mem) => mem.id === m.memberId);
       return {

--- a/src/pages/gallery/tool/talk-maker/index.tsx
+++ b/src/pages/gallery/tool/talk-maker/index.tsx
@@ -147,7 +147,9 @@ export default function TalkMakerPage() {
     link.download = 'talk-maker.json';
     link.href = url;
     link.click();
-    URL.revokeObjectURL(url);
+    // click() 直後に revoke するとダウンロードが開始する前にURLが
+    // 無効化され、ブラウザによってはダウンロードが失敗することがあるため遅延する
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   };
 
   const toggleSelect = (id: string) => {


### PR DESCRIPTION
## Summary
- 「トークアイコン」機能を廃止し、メンバーのアイコンに統一（ヘッダーのアイコン表示も削除）
- メンバーのアイコン編集をPopover化（絵文字グリッド + テキスト入力 + 画像アップロードを1箇所に集約）
- Copilotレビュー指摘を反映（クロップモーダルのズームクランプ・JSON空文字スキップ・Blob URL revokeタイミング）

## Fixes
- 2文字以上のアイコンが丸窓からはみ出す問題（表示側でフォントサイズを縮小）
- 吹き出しの尻尾がアバターに重なって見える問題（余白調整）
- 長い連続テキスト（名前ラベル・本文）がFlexboxのmin-width初期値のせいでmaxWを無視して伸びる問題
- 時刻が名前ラベルの幅に引っ張られて吹き出しから離れる問題
- PNG保存の画質劣化（実験的にpixelRatioを1にしていたのを2へ戻す）

## Test plan
- [x] yarn test（59テスト）
- [x] yarn lint
- [x] yarn dev で /gallery/tool/talk-maker を目視確認

## Saved image
<img width="760" height="794" alt="talk-maker-20260710182250" src="https://github.com/user-attachments/assets/fc2bcfcd-596c-4a20-9b57-123a387f76d5" />

## Screen Shot
<img width="1512" height="790" alt="スクリーンショット 2026-07-11 3 29 59" src="https://github.com/user-attachments/assets/33a09401-4041-417e-bc4e-e035e00cf26f" />
<img width="425" height="689" alt="スクリーンショット 2026-07-11 3 30 15" src="https://github.com/user-attachments/assets/cdae189f-6d31-4397-bc69-f6bba3113066" />

